### PR TITLE
Adjust colors to better adapt to partial color blindness user

### DIFF
--- a/components/Guesses/Highlight.tsx
+++ b/components/Guesses/Highlight.tsx
@@ -25,7 +25,7 @@ export const Letter: FC<LetterProps> = ({
         'uppercase',
         {
           'text-green-700': isCorrectIndex,
-          'text-yellow-700': isFoundInAnswer,
+          'text-yellow-500': isFoundInAnswer,
           'text-white': isCorrectAnswer
         }
       )}


### PR DESCRIPTION
Using green and yellow with the same lightness level is going to be a trouble from users with partial color blindness.

How it looked:
![image](https://user-images.githubusercontent.com/7252454/151657147-ffb02b4d-509c-4e1d-8300-da7d5db1d9d1.png)

In the image above, E and B are using `text-green-700` and U is using `text-yellow-700`. The image above is taken while simulating deuteranopia via Chrome devtools.

This PR adjusts the colors so it looks like this instead:
![image](https://user-images.githubusercontent.com/7252454/151657201-e1288019-a87a-4d20-9469-9461303df4af.png)

